### PR TITLE
Add github workflows for ci

### DIFF
--- a/.github/workflows/opensuse_TW-i386-fast.yml
+++ b/.github/workflows/opensuse_TW-i386-fast.yml
@@ -3,7 +3,7 @@ name: openSUSE TW i386 Fast Tests
 
 on:
   push:
-    branches: [ "main", "ci" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/opensuse_TW-i386-fast.yml
+++ b/.github/workflows/opensuse_TW-i386-fast.yml
@@ -1,0 +1,54 @@
+---
+name: openSUSE TW i386 Fast Tests
+
+on:
+  push:
+    branches: [ "main", "ci" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  tests-opensuse-tumbleweed-i386:
+
+    runs-on: ubuntu-22.04
+    container:
+      image: opensuse/tumbleweed
+      options: --platform "linux/386"
+
+    steps:
+    # Cache actions do not work for 32 containers on 64-bit runners
+    # - name: Cache action
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: /home/runner/work/_temp/_github_home/.ccache
+    #     # Necessary to cache the ccache data on every run
+    #     key: cache-oSTW-i386-fast-test-nopy-${{ github.run_id }}
+    #     restore-keys: |
+    #       cache-oSTW-i386-fast-test-nopy
+
+    - name: Install necessary packages
+      run: zypper --non-interactive install --no-recommends ccache gawk gcc-c++ hdf5-devel libboost_headers-devel libtool make pkgconfig python3 readline-devel "pkgconfig(armadillo)" "pkgconfig(eigen3)" "pkgconfig(fftw3)" "pkgconfig(gsl)" "pkgconfig(mpfr)" "pkgconfig(ncurses)"
+
+    - name: Git checkout
+      uses: actions/checkout@v1
+
+    - name: Set up autotools scripts
+      run:
+        ./autogen.sh
+
+    - name: Run configure
+      run: |
+        export CC='ccache gcc'
+        export CXX='ccache g++'
+        export CXXFLAGS+="-DO2SCL_PLAIN_HDF5_HEADER -DO2SCL_FAST_TEST"
+        export LDFLAGS+="-lgomp"
+        export CCACHE_DIR=~/.ccache
+        ./configure --build=i386-suse-linux --enable-shared --disable-static --enable-armadillo --enable-eigen --enable-fftw --enable-openmp --enable-ncurses --disable-pugixml --disable-python
+
+    - name: make
+      run: |
+        make VERBOSE=1 sinstall -j4 -O
+        make VERBOSE=1 -C data install-data
+
+    - name: make check
+      run: make VERBOSE=1 o2scl-test -j4 -O -k

--- a/.github/workflows/opensuse_TW-x86_64-fast.yml
+++ b/.github/workflows/opensuse_TW-x86_64-fast.yml
@@ -3,7 +3,7 @@ name: openSUSE TW x86_64 Fast Tests
 
 on:
   push:
-    branches: [ "main", "ci" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/opensuse_TW-x86_64-fast.yml
+++ b/.github/workflows/opensuse_TW-x86_64-fast.yml
@@ -1,0 +1,53 @@
+---
+name: openSUSE TW x86_64 Fast Tests
+
+on:
+  push:
+    branches: [ "main", "ci" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  tests-opensuse-tumbleweed-x86_64:
+
+    runs-on: ubuntu-latest
+    container:
+      image: opensuse/tumbleweed
+
+    steps:
+    - name: Cache action
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/_temp/_github_home/.ccache
+        # Necessary to cache the ccache data on every run
+        key: cache-oSTW-x86_64-fast-test-nopy-${{ github.run_id }}
+        restore-keys: |
+          cache-oSTW-x86_64-fast-test-nopy
+        save-always: true
+
+    - name: Install necessary packages
+      run: zypper --non-interactive install --no-recommends ccache gawk gcc-c++ hdf5-devel libboost_headers-devel libtool make pkgconfig python3 readline-devel "pkgconfig(armadillo)" "pkgconfig(eigen3)" "pkgconfig(fftw3)" "pkgconfig(gsl)" "pkgconfig(mpfr)" "pkgconfig(ncurses)"
+
+    - name: Git checkout
+      uses: actions/checkout@v4
+
+    - name: Set up autotools scripts
+      run:
+        ./autogen.sh
+
+    - name: Run configure
+      run: |
+        export CC='ccache gcc'
+        export CXX='ccache g++'
+        export CXXFLAGS+="-DO2SCL_PLAIN_HDF5_HEADER -DO2SCL_FAST_TEST"
+        export LDFLAGS+="-lgomp"
+        export CCACHE_DIR=~/.ccache
+        ./configure --build=x86_64-suse-linux --enable-shared --disable-static --enable-armadillo --enable-eigen --enable-fftw --enable-openmp --enable-ncurses --disable-pugixml --disable-python
+
+    - name: make
+      run: |
+        make VERBOSE=1 sinstall -j4 -O
+        make VERBOSE=1 -C data install-data
+
+    - name: make check
+      run: make VERBOSE=1 o2scl-test -j4 -O -k

--- a/.github/workflows/opensuse_TW-x86_64-full.yml
+++ b/.github/workflows/opensuse_TW-x86_64-full.yml
@@ -1,0 +1,53 @@
+---
+name: openSUSE TW x86_64 Full Tests
+
+on:
+  push:
+    branches: [ "main", "ci" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  fulltests-opensuse-tumbleweed-x86_64:
+
+    runs-on: ubuntu-latest
+    container:
+      image: opensuse/tumbleweed
+
+    steps:
+    - name: Cache action
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/_temp/_github_home/.ccache
+        # Necessary to cache the ccache data on every run
+        key: cache-oSTW-x86_64-full-test-nopy-${{ github.run_id }}
+        restore-keys: |
+          cache-oSTW-x86_64-full-test-nopy
+        save-always: true
+
+    - name: Install necessary packages
+      run: zypper --non-interactive install --no-recommends ccache gawk gcc-c++ hdf5-devel libboost_headers-devel libtool make pkgconfig python3 readline-devel "pkgconfig(armadillo)" "pkgconfig(eigen3)" "pkgconfig(fftw3)" "pkgconfig(gsl)" "pkgconfig(mpfr)" "pkgconfig(ncurses)"
+
+    - name: Git checkout
+      uses: actions/checkout@v4
+
+    - name: Set up autotools scripts
+      run:
+        ./autogen.sh
+
+    - name: Run configure
+      run: |
+        export CC='ccache gcc'
+        export CXX='ccache g++'
+        export CXXFLAGS+="-DO2SCL_PLAIN_HDF5_HEADER"
+        export LDFLAGS+="-lgomp"
+        export CCACHE_DIR=~/.ccache
+        ./configure --build=x86_64-suse-linux --enable-shared --disable-static --enable-armadillo --enable-eigen --enable-fftw --enable-openmp --enable-ncurses --disable-pugixml --disable-python
+
+    - name: make
+      run: |
+        make VERBOSE=1 sinstall -j4 -O
+        make VERBOSE=1 -C data install-data
+
+    - name: make check
+      run: make VERBOSE=1 o2scl-test -j4 -O -k

--- a/.github/workflows/opensuse_TW-x86_64-full.yml
+++ b/.github/workflows/opensuse_TW-x86_64-full.yml
@@ -3,7 +3,7 @@ name: openSUSE TW x86_64 Full Tests
 
 on:
   push:
-    branches: [ "main", "ci" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/ubuntu-x86_64-fast.yml
+++ b/.github/workflows/ubuntu-x86_64-fast.yml
@@ -1,0 +1,57 @@
+---
+name: Ubuntu amd64 Fast Tests
+
+on:
+  push:
+    branches: [ "main", "ci" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  tests-ubuntu-x86_64:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v4
+
+    - name: Cache action
+      uses: actions/cache@v4
+      with:
+        path: ~/.ccache
+        # Necessary to cache the ccache data on every run
+        key: cache-ubuntu-x86_64-fast-test-nopy-${{ github.run_id }}
+        restore-keys: |
+          cache-ubuntu-x86_64-fast-test-nopy
+        save-always: true
+
+    - name: Install and cache apt packages
+      # uses: awalsh128/cache-apt-pkgs-action@latest
+      # with:
+        # packages: ccache curl g++ gzip libarmadillo-dev libarpack2-dev libboost-all-dev libeigen3-dev libfftw3-dev libgsl-dev libhdf5-dev liblapack-dev libopenblas-dev libreadline-dev make tar
+        # version: 1.0
+      run: sudo apt-get -y update && sudo apt-get -y install ccache curl g++ gzip libarmadillo-dev libarpack2-dev libboost-all-dev libeigen3-dev libfftw3-dev libgsl-dev libhdf5-dev liblapack-dev libopenblas-dev libreadline-dev make tar
+
+    - name: Set up autotools scripts
+      run:
+        ./autogen.sh
+
+    - name: Configure
+      run: |
+        export CC='ccache gcc'
+        export CXX='ccache g++'
+        export CCACHE_DIR=~/.ccache
+        export CXXFLAGS+="-O3 -DO2SCL_FAST_TEST -DO2SCL_UBUNTU_HDF5 -DO2SCL_HDF5_PRE_1_12 -DO2SCL_HDF5_COMP -I/usr/include"
+        mkdir -p ${PWD}/build
+        ./configure --build=x86_64-ubuntu-linux --prefix=${PWD}/build --enable-shared --disable-static --enable-armadillo --enable-eigen --enable-fftw --enable-openmp --disable-python
+
+    - name: Build and install
+      run: |
+        make VERBOSE=1 sinstall -j4 -O
+        make VERBOSE=1 -C data install-data
+
+    - name: Check
+      run: |
+        export LD_LIBRAY_PATH+=:${PWD}/build
+        make VERBOSE=1 o2scl-test -j4 -O -k

--- a/.github/workflows/ubuntu-x86_64-fast.yml
+++ b/.github/workflows/ubuntu-x86_64-fast.yml
@@ -3,7 +3,7 @@ name: Ubuntu amd64 Fast Tests
 
 on:
   push:
-    branches: [ "main", "ci" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/ubuntu-x86_64-full.yml
+++ b/.github/workflows/ubuntu-x86_64-full.yml
@@ -3,7 +3,7 @@ name: Ubuntu amd64 Full Tests
 
 on:
   push:
-    branches: [ "main", "ci" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/ubuntu-x86_64-full.yml
+++ b/.github/workflows/ubuntu-x86_64-full.yml
@@ -1,0 +1,57 @@
+---
+name: Ubuntu amd64 Full Tests
+
+on:
+  push:
+    branches: [ "main", "ci" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  fulltests-ubuntu-x86_64:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v4
+
+    - name: Cache action
+      uses: actions/cache@v4
+      with:
+        path: ~/.ccache
+        # Necessary to cache the ccache data on every run
+        key: cache-ubuntu-x86_64-full-test-nopy-${{ github.run_id }}
+        restore-keys: |
+          cache-ubuntu-x86_64-full-test-nopy
+        save-always: true
+
+    - name: Install apt packages
+      # uses: awalsh128/cache-apt-pkgs-action@latest
+      # with:
+        # packages: ccache curl g++ gzip libarmadillo-dev libarpack2-dev libboost-all-dev libeigen3-dev libfftw3-dev libgsl-dev libhdf5-dev liblapack-dev libopenblas-dev libreadline-dev make tar
+        # version: 1.0
+      run: sudo apt-get -y update && sudo apt-get -y install ccache curl g++ gzip libarmadillo-dev libarpack2-dev libboost-all-dev libeigen3-dev libfftw3-dev libgsl-dev libhdf5-dev liblapack-dev libopenblas-dev libreadline-dev make tar
+
+    - name: Set up autotools scripts
+      run:
+        ./autogen.sh
+
+    - name: Configure
+      run: |
+        export CC='ccache gcc'
+        export CXX='ccache g++'
+        export CCACHE_DIR=~/.ccache
+        export CXXFLAGS+="-O3 -DO2SCL_UBUNTU_HDF5 -DO2SCL_HDF5_PRE_1_12 -DO2SCL_HDF5_COMP -I/usr/include"
+        mkdir -p ${PWD}/build
+        ./configure --build=x86_64-ubuntu-linux --prefix=${PWD}/build --enable-shared --disable-static --enable-armadillo --enable-eigen --enable-fftw --enable-openmp --disable-python
+
+    - name: Build and install
+      run: |
+        make VERBOSE=1 sinstall -j4 -O
+        make VERBOSE=1 -C data install-data
+
+    - name: Check
+      run: |
+        export LD_LIBRAY_PATH+=:${PWD}/build
+        make VERBOSE=1 o2scl-test -j4 -O -k


### PR DESCRIPTION
The following five workflows are set up to build and install O2SCL as a
shared library, and then run make check:
* openSUSE Tumbleweed i386: Fast suite of tests (make check fails).
* openSUSE Tumbleweed x86_64: Fast suite of tests (successful).
* openSUSE Tumbleweed x86_64: Full suite of tests (make check fails).
* Ubuntu x86_64: Fast suite of tests (successful).
* Ubuntu x86_64: Full suite of tests (successful).

All tests are configured to build with python bindings disabled as this
cannot be currently tested in this set-up anyway. Where possible ccache
is used to speed up repeated compilation of time-taking make and make
check.