### PR TITLE
Fix auto_format spacing when auto spacing disabled

### DIFF
--- a/src/base/auto_format.cpp
+++ b/src/base/auto_format.cpp
@@ -234,11 +234,14 @@ void auto_format::add_string(std::string s) {
     // we don't need a space
     size_t next_line=lines.size()-1;
     if (lines[next_line].length()==0 ||
-	lines[next_line][lines[next_line].length()-1]==' ') {
+        lines[next_line][lines[next_line].length()-1]==' ') {
       lines[next_line]+=s;
     } else if (auto_space) {
       // Otherwise, add a space
       lines[next_line]+=' '+s;
+    } else {
+      // Append the string without inserting an automatic space
+      lines[next_line]+=s;
     }
     
   } else {

--- a/src/base/auto_format_ts.cpp
+++ b/src/base/auto_format_ts.cpp
@@ -22,6 +22,7 @@
 */
 #include <o2scl/auto_format.h>
 #include <o2scl/test_mgr.h>
+#include <sstream>
 
 using namespace std;
 using namespace o2scl;
@@ -93,9 +94,21 @@ int main(void) {
   vv.push_back({1,3,4});
   vv.push_back({2,5});
   at << vv << endo;
-  
+
   at.done();
-  
+
+  // Verify that disabling automatic spacing still appends text
+  {
+    auto_format at_ns;
+    at_ns.auto_space=false;
+    std::ostringstream ss;
+    at_ns.attach(ss);
+    at_ns << "foo" << "bar" << endo;
+    at_ns.unattach();
+    t.test_abs<int>(ss.str().compare("foobar\n"),0,0,
+                    "auto_format respects disabled automatic spacing");
+  }
+
   t.report();
   return 0;
 }


### PR DESCRIPTION
## Summary
- ensure `auto_format` still appends text when automatic spacing is disabled
- extend the `auto_format_ts` test to cover the manual spacing scenario

## Testing
- not run (build system not configured in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9d39f68f88327be023f5eefcfb4f7