### PR TITLE
Fix table::function_find_row handling of table size edge cases

### DIFF
--- a/src/base/table.h
+++ b/src/base/table.h
@@ -3381,9 +3381,14 @@ namespace o2scl {
       }
       calc.compile(function.c_str(),&vars);
 
+      if (nlines==0) {
+        O2SCL_ERR("No rows in table::function_find_row().",o2scl::exc_einval);
+        return 0;
+      }
+
       fp_t best_val=0.0;
       size_t best_row=0;
-      for(size_t row=0;row<nlines-1;row++) {
+      for(size_t row=0;row<nlines;row++) {
         for(aciter it=atree.begin();it!=atree.end();it++) {
           vars[it->first]=it->second.dat[row];
         }

--- a/src/base/table_ts.cpp
+++ b/src/base/table_ts.cpp
@@ -121,6 +121,28 @@ int main(void) {
     at4.summary(&cout);
     at5.summary(&cout);
     swap(at4,at5);
+
+    // -------------------------------------------------------------
+    // Test function_find_row()
+
+    table<> find_tab;
+    find_tab.new_column("val");
+
+    double val_line[1];
+    val_line[0]=1.0;
+    find_tab.line_of_data(1,val_line);
+    val_line[0]=2.0;
+    find_tab.line_of_data(1,val_line);
+    val_line[0]=5.0;
+    find_tab.line_of_data(1,val_line);
+
+    size_t best=find_tab.function_find_row("val");
+    t.test_gen(best==2,"function_find_row() finds last row");
+
+    find_tab.set("val",2,-1.0);
+    find_tab.set("val",1,0.5);
+    best=find_tab.function_find_row("-val");
+    t.test_gen(best==2,"function_find_row() evaluates expressions");
   }
 
   {


### PR DESCRIPTION
## Summary
- prevent table::function_find_row() from running when the table has no rows and ensure all rows are scanned
- extend table tests to cover selecting the last row and expression handling in function_find_row()

## Testing
- not run (build system requires autotools helpers such as libtoolize that are unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb08e23be88327b71ec6423d9c81f2